### PR TITLE
Fix event listener

### DIFF
--- a/src/OhDearWebhooksEventSubscriber.php
+++ b/src/OhDearWebhooksEventSubscriber.php
@@ -8,32 +8,30 @@ use OhDear\LaravelWebhooks\OhDearWebhookCall;
 class OhDearWebhooksEventSubscriber
 {
     public function onUptimeCheckFailed(
-        OhDearWebhookCall $ohDearWebhookCall,
-        OhDearUptimeStore $ohDearUptimeStore
+        OhDearWebhookCall $ohDearWebhookCall
     ) {
         $site = $ohDearWebhookCall->site();
 
-        $ohDearUptimeStore->markSiteAsDown($site['url']);
+        (new OhDearUptimeStore)->markSiteAsDown($site['url']);
     }
 
     public function onUptimeCheckRecovered(
-        OhDearWebhookCall $ohDearWebhookCall,
-        OhDearUptimeStore $ohDearUptimeStore
+        OhDearWebhookCall $ohDearWebhookCall
     ) {
         $site = $ohDearWebhookCall->site();
 
-        $ohDearUptimeStore->markSiteAsUp($site['url']);
+        (new OhDearUptimeStore)->markSiteAsUp($site['url']);
     }
 
     public function subscribe(Dispatcher $events)
     {
         $events->listen(
-            'ohdear-webhooks::uptimeCheckFailed',
+            'ohdear-webhooks::uptimeCheckFailedNotification',
             static::class . '@onUptimeCheckFailed',
         );
 
         $events->listen(
-            'ohdear-webhooks::uptimeCheckRecovered',
+            'ohdear-webhooks::uptimeCheckRecoveredNotification',
             static::class . '@onUptimeCheckRecovered',
         );
     }


### PR DESCRIPTION
Fix event listener due to Oh Dear notification naming changes;
Fatal fix - Too few arguments to function Spatie\OhDearUptimeTile\OhDearWebhooksEventSubscriber::onUptimeCheckFailed(), 1 passed in ... and exactly 2 expected